### PR TITLE
Update frozendict version on requirements.txt

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -18,7 +18,7 @@ eth-typing==3.3.0
 eth-utils==2.1.0
 exceptiongroup==1.1.1
 fastecdsa==2.3.0
-frozendict==2.3.6
+frozendict==2.3.7
 frozenlist==1.3.3
 hexbytes==0.3.0
 idna==3.4


### PR DESCRIPTION
Version 2.3.6 appears to be broken. https://github.com/Marco-Sulla/python-frozendict/issues/78